### PR TITLE
Fix Github Action Path bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,5 @@ jobs:
       - name: Sonar-less-Scan
         uses: ./
         with:
-          sonar-organization: 'organization'
           sonar-project-version: '0.1'
           sonar-source-path: '.'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
         uses: ./
         with:
           sonar-project-version: '0.1'
-          sonar-source-path: '.'
+          sonar-source-path: 'test-src'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup-Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'oracle'
-          java-version: '21'
-
       - name: Sonar-less-Scan
         uses: ./
         with:

--- a/action.sh
+++ b/action.sh
@@ -56,8 +56,11 @@ function sonar-start() {
 function sonar-scan() {
     # 1. Get internal IP for Sonar-Server
     export DOCKER_SONAR_IP=$(docker inspect ${SONAR_INSTANCE_NAME} | jq -r '.[].NetworkSettings.IPAddress')
+
+    echo "SONAR_SOURCES: ${SONAR_SOURCES}"
+    echo "SONAR_SOURCE_PATH: ${SONAR_SOURCE_PATH}"
+
     # 2. Create token and scan
-    echo "SONAR_SOURCES: ${SONAR_SOURCES}/${SONAR_SOURCE_PATH}"
     export SONAR_TOKEN=$(curl -s -X POST -u "admin:sonar" "http://${DOCKER_SONAR_IP}:9000/api/user_tokens/generate?name=$(date +%s%N)" | jq -r .token)
     docker run --rm \
         -e SONAR_HOST_URL="http://${DOCKER_SONAR_IP}:9000"  \
@@ -65,8 +68,6 @@ function sonar-scan() {
         -e SONAR_SCANNER_OPTS="-Dsonar.projectKey=${SONAR_PROJECT_NAME} -Dsonar.sources=${SONAR_SOURCE_PATH}" \
         -v "${SONAR_SOURCES}:/usr/src" \
         sonarsource/sonar-scanner-cli
-
-            # -Dproject.settings=./sonar-project.properties
 
     # 3. Wait for scanning to be done
     printf '\nWaiting for analysis ' 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,7 @@ runs:
         SONAR_PROJECT_NAME: ${{inputs.sonar-project-name}}
         SONAR_PROJECT_KEY: ${{inputs.sonar-project-key}}
         SONAR_SOURCE_PATH: ${{inputs.sonar-source-path}}
+        SONAR_SOURCES: ${{ github.workspace }}
 
     - name: Scan Results
       run: make -C ${{ github.action_path }} sonar-results

--- a/action.yml
+++ b/action.yml
@@ -19,11 +19,11 @@ runs:
   using: "composite"
   steps:
     - name: Get Docker Deps
-      run: make sonar-docker-deps-get
+      run: make -C ${{ github.action_path }} sonar-docker-deps-get
       shell: bash
 
     - name: Scanning
-      run: make sonar-action
+      run: make -C ${{ github.action_path }} sonar-action
       shell: bash
       env:
         SONAR_PROJECT_NAME: ${{inputs.sonar-project-name}}
@@ -31,7 +31,7 @@ runs:
         SONAR_SOURCE_PATH: ${{inputs.sonar-source-path}}
 
     - name: Scan Results
-      run: make sonar-results
+      run: make -C ${{ github.action_path }} sonar-results
       shell: bash
       env:
         SONAR_PROJECT_NAME: ${{inputs.sonar-project-name}}


### PR DESCRIPTION
## Objective
Fix a bug where other repo that uses the action, can't run the sonar scanning commands. Turns out that I missed 2 things.
- Make gitrepo public
- put `${{ github.action_path }}` into the path so that it goes the right folder to execute the scripts.
(https://dev.to/n3wt0n/github-composite-actions-nest-actions-within-actions-3e5l)
